### PR TITLE
Dkwip node communications

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -18,28 +18,29 @@ NETWORK = NetworkAdapter.new
 Defaults.setup(settings.port)
 
 NODE = Defaults.create_node(NETWORK, settings.port)
+NODE.activate
 
 get '/', '/debug/node' do
    @title = "Node Info"
    @node = NODE
-   @super = NODE.is_super
-   @superport = ENV['SUPERPORT'] || 'none'
+   @super = @node.is_super
+   @superport = @node.superport || 'none'
    erb :node
  end
  
  get '/debug/buckets' do
    @title = "K-Buckets"
-   @super = NODE.is_super
-   @superport = ENV['SUPERPORT'] || 'none'
    @node = NODE
+   @super = @node.is_super
+   @superport = @node.superport || 'none'
    erb :buckets
  end
  
  get '/', '/debug/dht' do
    @title = "DHT Segment"
-   @super = NODE.is_super
-   @superport = ENV['SUPERPORT'] || 'none'
    @node = NODE
+   @super = @node.is_super
+   @superport = @node.superport || 'none'
    erb :dht
  end
 
@@ -84,6 +85,10 @@ post '/send_find_node' do
   @node = NODE
   erb :test
   # redirect '/'
+end
+
+get '/info' do
+  NODE.to_contact.to_json
 end
 
 post '/send_find_value' do

--- a/app.rb
+++ b/app.rb
@@ -21,15 +21,15 @@ NODE = Defaults.create_node(NETWORK, settings.port)
 
 get '/', '/debug/node' do
    @title = "Node Info"
-   @super = ENV['SUPER'] || 'false'
    @node = NODE
+   @super = NODE.is_super
    @superport = ENV['SUPERPORT'] || 'none'
    erb :node
  end
  
  get '/debug/buckets' do
    @title = "K-Buckets"
-   @super = ENV['SUPER'] || 'false'
+   @super = NODE.is_super
    @superport = ENV['SUPERPORT'] || 'none'
    @node = NODE
    erb :buckets
@@ -37,7 +37,7 @@ get '/', '/debug/node' do
  
  get '/', '/debug/dht' do
    @title = "DHT Segment"
-   @super = ENV['SUPER'] || 'false'
+   @super = NODE.is_super
    @superport = ENV['SUPERPORT'] || 'none'
    @node = NODE
    erb :dht

--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,7 @@
 require 'sinatra'
 require 'sinatra/reloader'
 require 'sinatra/multi_route'
+require 'sinatra/content_for'
 require 'json'
 require 'erubis'
 require 'pry'
@@ -52,6 +53,7 @@ post '/rpc/store' do
   address = params[:address]
   contact = Contact.new({id: params[:id], ip: params[:ip], port: params[:port].to_i})
   NODE.receive_store(file_id, address, contact)
+  status 200
 end
 
 post '/rpc/find_node' do
@@ -77,7 +79,7 @@ end
 post '/send_find_node' do
   query_id = params[:query_id]
   
-  @contacts = NODE.iterative_find_node(query_id)
+  @result = NODE.iterative_find_node(query_id)
   
   @node = NODE
   erb :test
@@ -87,18 +89,36 @@ end
 post '/send_find_value' do
   query_id = params[:file_id]
   
-  @contacts = NODE.iterative_find_value(query_id)
+  @result = NODE.iterative_find_value(query_id)
   
   @node = NODE
   erb :test
   # redirect '/'
 end
 
-post '/send_store' do
+post '/send_rpc_store' do
   key = params[:key]
   data = params[:data]
-  NODE.iterate_store(key, data)
 
+  contact = Contact.new(id: params[:id], ip: params[:ip], port: params[:port])
+  NODE.store(key, data, contact)
+  redirect '/'
+end
+
+post '/send_it_store' do
+  key = params[:key]
+  data = params[:data]
+  NODE.iterative_store(key, data)
+
+  redirect '/'
+end
+
+post '/send_rpc_ping' do
+  id = params[:id]
+  ip = params[:ip]
+  port = params[:port]
+  contact = Contact.new({id: params[:id], ip: params[:ip], port: params[:port].to_i})
+  NODE.ping(contact)
   redirect '/'
 end
 

--- a/bin/launch_nodes.sh
+++ b/bin/launch_nodes.sh
@@ -24,6 +24,7 @@ help_message() {
 
 launch_nodes() {
   launch_super $1
+  sleep 1
   SUPERPORT=$1
   for port in ${@:2}
   do

--- a/lib/defaults.rb
+++ b/lib/defaults.rb
@@ -27,7 +27,7 @@ module Defaults
     else
       node = Node.new(new_id, network, port)
     end
-
+    node.promote if ENV['SUPER'] == 'true'
     node.sync
     node
   end

--- a/lib/fake_network_adapter.rb
+++ b/lib/fake_network_adapter.rb
@@ -33,6 +33,10 @@ class FakeNetworkAdapter
     recipient_node.receive_find_value(file_id, sender_contact)
   end
 
+  def get_info
+    
+  end
+
   def ping(contact, sender_contact)
     recipient_node = get_node_by_contact(contact)
     

--- a/lib/fake_network_adapter.rb
+++ b/lib/fake_network_adapter.rb
@@ -1,0 +1,47 @@
+class FakeNetworkAdapter
+  attr_accessor :nodes
+
+  def initialize
+    @nodes = []
+  end
+
+  def get_node_by_contact(contact)
+    @nodes.find {|n| n.id == contact.id }
+  end
+
+  def store(file_id, address, recipient_contact, sender_contact)
+    recipient_node = get_node_by_contact(recipient_contact)
+    recipient_node.receive_store(file_id, address, sender_contact)
+    node = get_node_by_contact(sender_contact)
+    node.ping(recipient_contact)
+    return
+  end
+
+  def find_node(query_id, recipient_contact, sender_contact)
+    recipient_node = get_node_by_contact(recipient_contact)
+    closest_nodes = recipient_node.receive_find_node(query_id, sender_contact)
+    node = get_node_by_contact(sender_contact)
+    node.ping(recipient_contact)
+
+    closest_nodes
+  end
+
+  def find_value(file_id, recipient_contact, sender_contact)
+    recipient_node = get_node_by_contact(recipient_contact)
+    node = get_node_by_contact(sender_contact)
+    node.ping(recipient_contact)
+    recipient_node.receive_find_value(file_id, sender_contact)
+  end
+
+  def ping(contact, sender_contact)
+    recipient_node = get_node_by_contact(contact)
+    
+    if recipient_node
+      recipient_node.receive_ping(sender_contact)
+      contact.update_last_seen
+      return true
+    else
+      return false
+    end
+  end
+end

--- a/lib/network_adapter.rb
+++ b/lib/network_adapter.rb
@@ -1,4 +1,5 @@
 require 'http'
+require_relative 'contact.rb'
 
 class NetworkAdapter
   attr_accessor :nodes
@@ -7,58 +8,45 @@ class NetworkAdapter
     @nodes = []
   end
 
-  def get_node_by_contact(contact)
-    @nodes.find {|n| n.id == contact.id }
-  end
-
   def store(file_id, address, recipient_contact, sender_contact)
-    if ENV['development'] == 'true'
-      recipient_node = get_node_by_contact(recipient_contact)
-      recipient_node.receive_store(file_id, address, sender_contact)
-      node = get_node_by_contact(sender_contact)
-      node.ping(recipient_contact)
-      # ping(recipient_contact)
-    else
-      info_hash = {:file_id => file_id, :address => address, :port => sender_contact.port, :id => sender_contact.id, :ip => sender_contact.ip }
-      url = recipient_contact.ip
-      port = recipient_contact.port
-      call_rpc_store(url, port, info_hash)
-      
-      response
-    end
+    info_hash = {:file_id => file_id, :address => address, :port => sender_contact.port, :id => sender_contact.id, :ip => sender_contact.ip }
+    url = recipient_contact.ip
+    port = recipient_contact.port
+    response = call_rpc_store(url, port, info_hash)
+    response
   end
 
   def find_node(query_id, recipient_contact, sender_contact)
-    if ENV['development'] == 'true'
-      recipient_node = get_node_by_contact(recipient_contact)
-      closest_nodes = recipient_node.receive_find_node(query_id, sender_contact)
-      node = get_node_by_contact(sender_contact)
-      node.ping(recipient_contact)
-
-      closest_nodes
-    else
-      info_hash = {:node_id => query_id, :id => sender_contact.id, :port => sender_contact.port}
-      response = call_rpc_find_node(recipient_contact.ip, recipient_contact.port, info_hash)
-      closest_nodes = JSON.parse(response)      
-      closest_nodes.map! { |contact| Contact.new({ id: contact['id'], ip: contact['ip'], port: contact['port'].to_i }) }
-    end
+    info_hash = {:node_id => query_id, :id => sender_contact.id, :port => sender_contact.port}
+    response = call_rpc_find_node(recipient_contact.ip, recipient_contact.port, info_hash)
+    closest_nodes = JSON.parse(response)      
+    closest_nodes.map! { |contact| Contact.new({ id: contact['id'], ip: contact['ip'], port: contact['port'].to_i }) }
   end
 
   def find_value(file_id, recipient_contact, sender_contact)
-    if ENV['development'] == 'true'
-      recipient_node = get_node_by_contact(recipient_contact)
-      node = get_node_by_contact(sender_contact)
-      node.ping(recipient_contact)
-      result = recipient_node.receive_find_value(file_id, sender_contact)
-    else
-      info_hash = {:file_id => file_id, :id => sender_contact.id, :port => sender_contact.port}
-      response = call_rpc_find_value(recipient_contact.ip, recipient_contact.port, info_hash)
-      result = JSON.parse(response)
-
-      # closest_node['contacts']
-      # closest_node['data']
-
+    info_hash = {:file_id => file_id, :id => sender_contact.id, :port => sender_contact.port}
+    response = call_rpc_find_value(recipient_contact.ip, recipient_contact.port, info_hash)
+    result = JSON.parse(response)
+    if result['contacts']
+      result['contacts'].map! { |contact| Contact.new({ id: contact['id'], ip: contact['ip'], port: contact['port'].to_i }) }
     end
+    result
+    
+    # closest_node['contacts']
+    # closest_node['data']
+  end
+
+  def ping(contact, sender_contact)
+    info_hash = {:port => sender_contact.port, :id => sender_contact.id, :ip => sender_contact.ip }
+    response = call_rpc_ping(contact.ip, contact.port, info_hash)
+    return response.code == 200
+  end
+
+
+  private 
+
+  def call_rpc_ping(url, port, info_hash)
+    HTTP.post('http://' + url + ':' + port.to_s + '/rpc/ping', :form => info_hash)
   end
 
   def call_rpc_store(url, port, info_hash)

--- a/lib/network_adapter.rb
+++ b/lib/network_adapter.rb
@@ -58,6 +58,15 @@ class NetworkAdapter
     return response.code == 200
   end
 
+  def get_info(url, port)
+    begin
+      response = call_get_info(url, port)
+    rescue
+      response = '{}'
+    end
+    response
+  end
+
 
   private 
 
@@ -76,6 +85,10 @@ class NetworkAdapter
 
   def call_rpc_find_value(url, port, info_hash)
     HTTP.post('http://' + url + ':' + port.to_s + '/rpc/find_value', :form => info_hash)
+  end
+
+  def call_get_info(url, port)
+    HTTP.get('http://' + url + ':' + port.to_s + '/info')
   end
 end
 

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -6,6 +6,7 @@ require_relative 'routing_table.rb'
 require_relative 'contact.rb'
 require_relative 'network_adapter.rb'
 require_relative 'storage.rb'
+require 'pry'
 
 
 class Node
@@ -18,7 +19,7 @@ class Node
     # @id = Binary.sha(num_string) # TEMP - using a fixed string for now to generate ID hash
     @id = num_string
     @routing_table = RoutingTable.new(self)
-    @files = generate_file_cache
+    generate_file_cache
     @dht_segment = {}
   end
 
@@ -39,8 +40,7 @@ class Node
       file_hash = Binary.sha(File.basename(file))
       cache[file_hash] = File.basename(file)
     end
-
-    @files =  cache
+    @files = cache
     sync
   end
   
@@ -50,30 +50,30 @@ class Node
 
   def receive_ping(contact)
     @routing_table.insert(contact)
-    sync
   end
 
   def ping(contact)
-    recipient_node = @network.get_node_by_contact(contact)
+    response = @network.ping(contact, to_contact)
+    # recipient_node = @network.get_node_by_contact(contact)
 
-    if recipient_node
-      recipient_node.receive_ping(self.to_contact)
-      contact.update_last_seen
-      @routing_table.insert(contact)
-    end 
-
-    recipient_node
+    # if recipient_node
+    #   recipient_node.receive_ping(self.to_contact)
+    #   contact.update_last_seen
+    #   @routing_table.insert(contact)
+    # end 
+    @routing_table.insert(contact) if response
+    response
   end
 
   def store(file_id, address, recipient_contact)
-    @network.store(file_id, address, recipient_contact, self.to_contact)
+    response = @network.store(file_id, address, recipient_contact, self.to_contact)
+    @routing_table.insert(recipient_contact) if response && response.code == 200
   end
 
   def receive_store(file_id, address, sender_contact)
     @dht_segment[file_id] = address
     @routing_table.insert(sender_contact)
-    ping(sender_contact)
-    sync
+    # ping(sender_contact)
   end
 
   def iterative_store(file_id, address)
@@ -91,7 +91,7 @@ class Node
     # have to exclude the requestor contact
 
     closest_contacts = @routing_table.find_closest_contacts(query_id, sender_contact)
-    ping(sender_contact)
+    # ping(sender_contact)
     @routing_table.insert(sender_contact)
     closest_contacts
   end
@@ -150,7 +150,7 @@ class Node
       result['contacts'] = receive_find_node(file_id, sender_contact)
     end
     @routing_table.insert(sender_contact)
-    ping(sender_contact)
+    # ping(sender_contact)
     result
   end
 
@@ -164,7 +164,7 @@ class Node
     shortlist = []
     results_returned = @routing_table.find_closest_contacts(query_id, nil, ENV['alpha'].to_i)
 
-    until shortlist.select(&:active).size == ENV['k'].to_i + 1
+    until shortlist.select(&:active).size == ENV['k'].to_i
       shortlist.push(results_returned.pop.clone) until results_returned.empty? || shortlist.size == ENV['k'].to_i
       # closest_contact = Binary.select_closest_xor(query_id, shortlist)
       Binary.sort_by_xor!(id, shortlist)
@@ -178,7 +178,7 @@ class Node
           # When this function succeeds (finds the value), a STORE RPC is sent to
           # the closest Contact which did not return the value.
           second_closest = shortlist.find { |c| c.id != contact.id }
-          store(query_id, temp_results['data'], second_closest)
+          store(query_id, temp_results['data'], second_closest) if second_closest
  
           return temp_results['data']
         end

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -183,8 +183,10 @@ class Node
           return temp_results['data']
         end
 
-        temp_results['contacts'].each do |t|
-          results_returned.push(t) if contact_is_not_in_results_or_shortlist(t, results_returned, shortlist)
+        if temp_results['contacts']
+          temp_results['contacts'].each do |t|
+            results_returned.push(t) if contact_is_not_in_results_or_shortlist(t, results_returned, shortlist)
+          end
         end
         #happy path only.. contact will be marked as probed when queried, then marked as active if we receive a reply
         #contact stays in probed mode until reply is received.

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -6,11 +6,12 @@ require_relative 'routing_table.rb'
 require_relative 'contact.rb'
 require_relative 'network_adapter.rb'
 require_relative 'storage.rb'
+require 'json'
 require 'pry'
 
 
 class Node
-  attr_accessor :ip, :id, :port, :files, :routing_table, :dht_segment, :is_super
+  attr_accessor :ip, :id, :port, :files, :routing_table, :dht_segment, :is_super, :superport
   def initialize(num_string, network, port='80', is_super=false)
     @ip = lookup_ip
     @network = network
@@ -22,10 +23,19 @@ class Node
     generate_file_cache
     @dht_segment = {}
     @is_super = false
+    @superport = nil
   end
 
   def promote
     @is_super = true
+  end
+
+  def activate
+    return if is_super
+    @superport = ENV['SUPERPORT']
+    result = JSON.parse(@network.get_info('localhost', @superport))
+    contact = Contact.new(id: result['id'], ip: result['ip'], port: result['port'])
+    ping(contact)
   end
 
   def join(network)

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -10,8 +10,8 @@ require 'pry'
 
 
 class Node
-  attr_accessor :ip, :id, :port, :files, :routing_table, :dht_segment
-  def initialize(num_string, network, port='80')
+  attr_accessor :ip, :id, :port, :files, :routing_table, :dht_segment, :is_super
+  def initialize(num_string, network, port='80', is_super=false)
     @ip = lookup_ip
     @network = network
     @port = port
@@ -21,6 +21,11 @@ class Node
     @routing_table = RoutingTable.new(self)
     generate_file_cache
     @dht_segment = {}
+    @is_super = false
+  end
+
+  def promote
+    @is_super = true
   end
 
   def join(network)

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -3,6 +3,7 @@ body {
   color: white;
   font-family: 'Courier New';
   font-weight: 100;
+  min-width: 1200px
 }
 
 dd {
@@ -13,7 +14,7 @@ header {
 }
 header nav {
   margin: 0 auto;
-  width: 700px;
+  width: 800px;
 }
 
 header nav dl{
@@ -22,6 +23,20 @@ header nav dl{
   margin: 20px 10px;
 }
 
+div.forms {
+  float: left;
+  width: 280px
+}
+
+div.forms form {
+  border: 1px solid white;
+  padding: 5px
+}
+
+div.list {
+  float: left;
+  margin-left: 40px;
+}
 nav a {
   text-decoration: none;
   border: 1px solid white;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -70,17 +70,18 @@ nav dl dd, nav dl dt {
 }
 
 div.files, div.dht, div.buckets {
-  width: 700px;
+  width: 800px;
   margin: 0 auto
 }
 
 div.buckets ul {
-  width: 313px
+  width: 630px
 }
 
 div.buckets li {
   list-style-type: none;
-  text-align: right;
+  text-align: left;
+  margin-left: 60px
 }
 
 div.files dd, div.dht dd{

--- a/test/contact_test.rb
+++ b/test/contact_test.rb
@@ -1,11 +1,11 @@
 require_relative 'test_helper.rb'
 require_relative '../lib/node.rb'
 require_relative "../lib/contact.rb"
-require_relative "../lib/network_adapter.rb"
+require_relative "../lib/fake_network_adapter.rb"
 
 class ContactTest < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
     @node = Node.new('0', @kn)
     @options = {
       :id => @node.id,

--- a/test/kbucket_160bit_test.rb
+++ b/test/kbucket_160bit_test.rb
@@ -3,11 +3,11 @@ require_relative '../lib/node.rb'
 require_relative "../lib/routing_table.rb"
 require_relative "../lib/kbucket.rb"
 require_relative "../lib/contact.rb"
-require_relative "../lib/network_adapter.rb"
+require_relative "../lib/fake_network_adapter.rb"
 
 class KBucketTest160 < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
     @node = Node.new('0', @kn)
     @bucket = KBucket.new(@node)
     @contact = @node.to_contact

--- a/test/kbucket_4bit_test.rb
+++ b/test/kbucket_4bit_test.rb
@@ -3,11 +3,11 @@ require_relative '../lib/node.rb'
 require_relative "../lib/routing_table.rb"
 require_relative "../lib/kbucket.rb"
 require_relative "../lib/contact.rb"
-require_relative "../lib/network_adapter.rb"
+require_relative "../lib/fake_network_adapter.rb"
 
 class KBucketTest < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
     @node = Node.new('0', @kn)
     @bucket = KBucket.new(@node)
     @contact = @node.to_contact

--- a/test/kbucket_6bit_test.rb
+++ b/test/kbucket_6bit_test.rb
@@ -3,11 +3,11 @@ require_relative '../lib/node.rb'
 require_relative "../lib/routing_table.rb"
 require_relative "../lib/kbucket.rb"
 require_relative "../lib/contact.rb"
-require_relative "../lib/network_adapter.rb"
+require_relative "../lib/fake_network_adapter.rb"
 
 class KBucketTest6 < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
     @node = Node.new('0', @kn)
     @bucket = KBucket.new(@node)
     @contact = @node.to_contact

--- a/test/network_adapter_test.rb
+++ b/test/network_adapter_test.rb
@@ -1,13 +1,13 @@
 require_relative 'test_helper.rb'
-require_relative '../lib/network_adapter.rb'
+require_relative '../lib/fake_network_adapter.rb'
 
 class NetworkAdapterTest < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
   end
 
   def test_create_network_adapter
-    assert_instance_of(NetworkAdapter, @kn)
+    assert_instance_of(FakeNetworkAdapter, @kn)
   end
 
   def test_kn_has_nodes

--- a/test/node_160bit_test.rb
+++ b/test/node_160bit_test.rb
@@ -1,12 +1,12 @@
 require_relative 'test_helper.rb'
 require_relative "../lib/node.rb"
 require_relative "../lib/routing_table.rb"
-require_relative "../lib/network_adapter.rb"
+require_relative "../lib/fake_network_adapter.rb"
 require_relative "../lib/kbucket.rb"
 
 class NodeTest160 < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
     ENV['bit_length'] = '160'
     ENV['k'] = '2'
   end

--- a/test/node_4bit_test.rb
+++ b/test/node_4bit_test.rb
@@ -1,12 +1,12 @@
 require_relative 'test_helper.rb'
 require_relative "../lib/node.rb"
 require_relative "../lib/routing_table.rb"
-require_relative "../lib/network_adapter.rb"
+require_relative "../lib/fake_network_adapter.rb"
 require_relative "../lib/kbucket.rb"
 
 class NodeTest < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
     ENV['bit_length'] = '4'
     ENV['k'] = '2'
   end

--- a/test/node_6bit_test.rb
+++ b/test/node_6bit_test.rb
@@ -1,12 +1,12 @@
 require_relative 'test_helper.rb'
 require_relative "../lib/node.rb"
 require_relative "../lib/routing_table.rb"
-require_relative "../lib/network_adapter.rb"
+require_relative "../lib/fake_network_adapter.rb"
 require_relative "../lib/kbucket.rb"
 
 class NodeTest6 < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
     ENV['bit_length'] = '6'
     ENV['k'] = '2'
   end

--- a/test/routing_table_160bit_test.rb
+++ b/test/routing_table_160bit_test.rb
@@ -3,11 +3,11 @@ require_relative '../lib/node.rb'
 require_relative "../lib/routing_table.rb"
 require_relative "../lib/kbucket.rb"
 require_relative "../lib/contact.rb"
-require_relative "../lib/network_adapter.rb"
+require_relative "../lib/fake_network_adapter.rb"
 
 class RoutingTableTest160 < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
     @node = Node.new('0', @kn)
     @routing_table = @node.routing_table
     ENV['bit_length'] = '160'

--- a/test/routing_table_4bit_test.rb
+++ b/test/routing_table_4bit_test.rb
@@ -3,11 +3,11 @@ require_relative '../lib/node.rb'
 require_relative "../lib/routing_table.rb"
 require_relative "../lib/kbucket.rb"
 require_relative "../lib/contact.rb"
-require_relative "../lib/network_adapter.rb"
+require_relative "../lib/fake_network_adapter.rb"
 
 class RoutingTableTest < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
     @node = Node.new('0', @kn)
     @routing_table = @node.routing_table
     ENV['bit_length'] = '4'

--- a/test/routing_table_6bit_test.rb
+++ b/test/routing_table_6bit_test.rb
@@ -3,11 +3,11 @@ require_relative '../lib/node.rb'
 require_relative "../lib/routing_table.rb"
 require_relative "../lib/kbucket.rb"
 require_relative "../lib/contact.rb"
-require_relative "../lib/network_adapter.rb"
+require_relative "../lib/fake_network_adapter.rb"
 
 class RoutingTableTest6 < Minitest::Test
   def setup
-    @kn = NetworkAdapter.new
+    @kn = FakeNetworkAdapter.new
     @node = Node.new('0', @kn)
     @routing_table = @node.routing_table
     ENV['bit_length'] = '6'

--- a/views/buckets.erb
+++ b/views/buckets.erb
@@ -23,7 +23,7 @@
             <ul>
              <% b.contacts. each do |c| %>
               <li>id: <%= c.id %></li>
-              <li>ip: <%= c.ip %>:<%= c.port %></li>
+              <li>ip: <a href="http://<%= c.ip %>:<%= c.port %>"><%= c.ip %>:<%= c.port %></a></li>
               <li>lastseen: <%= c.last_seen %></li>
               <li>---------------------</li>
               <% end %>

--- a/views/buckets.erb
+++ b/views/buckets.erb
@@ -22,8 +22,10 @@
           <dd>
             <ul>
              <% b.contacts. each do |c| %>
-              <li>id: <%= c.id %>  ip: <%= c.ip %>:<%= c.port %>
-              </li>
+              <li>id: <%= c.id %></li>
+              <li>ip: <%= c.ip %>:<%= c.port %></li>
+              <li>lastseen: <%= c.last_seen %></li>
+              <li>---------------------</li>
               <% end %>
             </ul>
           </dd>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -38,27 +38,57 @@
     </nav>
   </header>
   <main>
-    <form action="/send_find_node" method="post">
-      <h1>Iterate find node</h1>
-      <p>Query id</p>
-      <input type="text" id="query_id" name="query_id">
-      <input type="submit" value="submit">
-    </form>
-    <form action="/send_find_value" method="post">
-      <h1>Iterate find value</h1>
-      <p>Query file_id</p>
-      <input type="text" id="file_id" name="file_id">
-      <input type="submit" value="submit">
-    </form>
-    <form action="/send_store" method="post">
-      <h1>Iterate store</h1>
-      <p>Store key</p>
-      <input type="text" id="key" name="key">
-      <p>Store data(address?)</p>
-      <input type="text" id="data" name="data">
-      <input type="submit" value="submit">
-    </form>
-    <%= yield %>
+    <div class="forms">
+      <form action="/send_find_node" method="post">
+        <fieldset>
+        <h4>Iterative find node</h4>
+        <p>Query id</p>
+        <input type="text" id="query_id" name="query_id">
+        <input type="submit" value="submit">
+        </fieldset>
+      </form>
+      <form action="/send_find_value" method="post">
+        <h4>Iterative find value</h3>
+        <p>Query file_id</p>
+        <input type="text" id="file_id" name="file_id">
+        <input type="submit" value="submit">
+      </form>
+      <form action="/send_it_store" method="post">
+        <h4>Iterative store</h4>
+        <p>Store key</p>
+        <input type="text" id="key" name="key">
+        <p>Store data(address?)</p>
+        <input type="text" id="data" name="data">
+        <input type="submit" value="submit">
+      </form>
+      <form action="/send_rpc_store" method="post">
+        <h4>Send RPC Store</h4>
+        <p>Store key</p>
+        <input type="text" id="key" name="key">
+        <p>Store data(address?)</p>
+        <input type="text" id="data" name="data">
+        <p>Recipient IP</p>
+        <input type="text" id="ip" name="ip">        
+        <p>Recipient Port</p>
+        <input type="text" id="port" name="port">
+        <p>Recipient ID</p>
+        <input type="text" id="id" name="id">
+        <input type="submit" value="submit">
+      </form>
+      <form action="/send_rpc_ping" method="post">
+        <h4>Send Ping</h4>
+        <p>Recipient IP</p>
+        <input type="text" id="ip" name="ip">        
+        <p>Recipient Port</p>
+        <input type="text" id="port" name="port">
+        <p>Recipient ID</p>
+        <input type="text" id="id" name="id">
+        <input type="submit" value="submit">
+      </form>
+    </div>
+    <div class="list">
+      <%= yield %>
+    </div>
   </main>
 </body>
 </html>

--- a/views/test.erb
+++ b/views/test.erb
@@ -1,2 +1,8 @@
-<p><%= @contacts %></p>
+<% if @result.class == Array %>
+  <% @result.each do |c| %>
+    <p><%= c.id %> </p>
+  <% end %>
+<% else %>
+  <p><%= @result %></p>
+<% end %>
 


### PR DESCRIPTION
all tests pass provided alpha=1 -- we need to adjust for a higher alpha ASAP, as results returned from iterative methods aren't accurate.

this was mainly a bunch of cleanup of loose ends in inter-node communication.  

main developments:  

- FakeNetworkAdapter class in tests to stub out network calls in fake env

- supernode attributes are passed from cli, to ENV (sinatra), to Node object

- HTTP Calls in Real network are protected in begin/rescue blocks as to not crash app when querying not-existent node

-Startup script sleeps 1 second after launching supernode, client nodes ping supernode at boot and thus save info in eachother's routing tables

- Formatting cleanup
