### PR TITLE
Bucket alpha tests

### DIFF
--- a/lib/kbucket.rb
+++ b/lib/kbucket.rb
@@ -2,7 +2,7 @@ require_relative '../development.rb'
 require_relative 'binary.rb'
 
 class KBucket
-  K = ENV['k'].to_i # hardcoding k value for now
+  # K = ENV['k'].to_i # hardcoding k value for now
   attr_reader :splittable
   attr_accessor :contacts, :node
 
@@ -29,7 +29,7 @@ class KBucket
   end
 
   def is_full?
-    @contacts.size == K
+    @contacts.size == ENV['k'].to_i
   end
 
   # is this the bucket that has the longest shared_bits_length?

--- a/test/kbucket_160bit_8k_3a_test.rb
+++ b/test/kbucket_160bit_8k_3a_test.rb
@@ -1,0 +1,176 @@
+require_relative 'test_helper.rb'
+require_relative '../lib/node.rb'
+require_relative "../lib/routing_table.rb"
+require_relative "../lib/kbucket.rb"
+require_relative "../lib/contact.rb"
+require_relative "../lib/fake_network_adapter.rb"
+
+class KBucketTest160bit8k < Minitest::Test
+  def setup
+    @kn = FakeNetworkAdapter.new
+    @node = Node.new('0', @kn)
+    @bucket = KBucket.new(@node)
+    @contact = @node.to_contact
+    ENV['bit_length'] = '160'
+    ENV['k'] = '8'
+    ENV['alpha'] = '3'
+  end
+
+  def test_create_bucket
+    assert_instance_of(KBucket, @bucket)
+    assert_equal([], @bucket.contacts)
+    assert_equal(true, @bucket.splittable)
+  end
+
+  def test_add_contact
+    @bucket.add(@contact)
+
+    assert_equal(1, @bucket.contacts.size)
+  end
+
+  def test_delete_contact
+    @bucket.add(@contact)
+    @bucket.delete(@bucket.contacts[0])
+
+    assert_equal(0, @bucket.contacts.size)
+  end
+
+  def test_delete_contact_that_is_not_included
+    @bucket.add(@contact)
+    contact = Node.new('1', @kn).to_contact
+    @bucket.delete(contact)
+
+    assert_equal(1, @bucket.contacts.size)
+  end
+
+  def test_head_tail_one_contact
+    @bucket.add(@contact)
+
+    assert_equal(@bucket.contacts[0], @bucket.head)
+    assert_equal(@bucket.contacts[0], @bucket.tail)
+  end
+
+  def test_head_tail_two_contacts
+    @bucket.add(@contact)
+    @bucket.add({ :id => '1', :ip => '' })
+
+    assert_equal(@bucket.contacts[0], @bucket.head)
+    assert_equal(@bucket.contacts[1], @bucket.tail)
+  end
+
+  def test_bucket_is_full
+    @bucket.add(@contact)
+    @bucket.add({ :id => '1', :ip => '' })
+    @bucket.add({ :id => '2', :ip => '' })
+    @bucket.add({ :id => '3', :ip => '' })
+    @bucket.add({ :id => '4', :ip => '' })
+    @bucket.add({ :id => '5', :ip => '' })
+    @bucket.add({ :id => '6', :ip => '' })
+    @bucket.add({ :id => '7', :ip => '' })
+
+    assert(@bucket.is_full?)
+  end
+
+  def test_bucket_is_not_full
+    @bucket.add(@contact)
+
+    refute(@bucket.is_full?)
+  end
+
+  def test_find_contact_by_id
+    @bucket.add(@contact)
+    found_contact = @bucket.find_contact_by_id(@node.id)
+
+    assert_equal(@bucket.contacts[0], found_contact)
+  end
+
+  def test_find_contact_by_id_no_match
+    @bucket.add(@contact)
+    found_contact = @bucket.find_contact_by_id('1')
+
+    assert_nil(found_contact)
+  end
+
+  def test_make_unsplittable
+    @bucket.make_unsplittable
+
+    refute(@bucket.splittable)
+  end
+
+  def test_is_redistributable
+    no_shared_id = ((2 ** ENV['bit_length'].to_i) - 1).to_s
+    no_shared_id2 = ((2 ** ENV['bit_length'].to_i) - 2).to_s
+    no_shared_id3 = ((2 ** ENV['bit_length'].to_i) - 3).to_s
+    no_shared_id4 = ((2 ** ENV['bit_length'].to_i) - 4).to_s
+    no_shared_id5 = ((2 ** ENV['bit_length'].to_i) - 5).to_s
+    no_shared_id6 = ((2 ** ENV['bit_length'].to_i) - 6).to_s
+    no_shared_id7 = ((2 ** ENV['bit_length'].to_i) - 7).to_s
+    shared_bits_id = '1'
+    
+    @bucket.add(Node.new(no_shared_id, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id2, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id3, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id4, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id5, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id6, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id7, @kn).to_contact)
+    @bucket.add(Node.new(shared_bits_id, @kn).to_contact)
+
+    result = @bucket.is_redistributable?('0', 0)
+    assert(result)
+  end
+
+  def test_is_not_redistributable
+    no_shared_id = ((2 ** ENV['bit_length'].to_i) - 1).to_s
+    no_shared_id2 = ((2 ** ENV['bit_length'].to_i) - 2).to_s
+    no_shared_id3 = ((2 ** ENV['bit_length'].to_i) - 3).to_s
+    no_shared_id4 = ((2 ** ENV['bit_length'].to_i) - 4).to_s
+    no_shared_id5 = ((2 ** ENV['bit_length'].to_i) - 5).to_s
+    no_shared_id6 = ((2 ** ENV['bit_length'].to_i) - 6).to_s
+    no_shared_id7 = ((2 ** ENV['bit_length'].to_i) - 7).to_s
+    no_shared_id8 = ((2 ** ENV['bit_length'].to_i) - 8).to_s
+    
+    @bucket.add(Node.new(no_shared_id, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id2, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id3, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id4, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id5, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id6, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id7, @kn).to_contact)
+    @bucket.add(Node.new(no_shared_id8, @kn).to_contact)
+
+    result = @bucket.is_redistributable?('0', 0)
+    refute(result)
+  end
+
+  def test_sort_by_seen
+    @bucket.add(@contact)
+    @bucket.add(Node.new('7', @kn).to_contact)
+
+    @bucket.head.update_last_seen
+    @bucket.sort_by_seen
+
+    assert_equal('7', @bucket.head.id)
+  end
+
+  def test_attempt_eviction_pingable
+    @bucket.add(Node.new('15', @kn).to_contact)
+    @bucket.add(Node.new('14', @kn).to_contact)
+
+    @bucket.attempt_eviction(Contact.new(id: '13', ip: ''))
+
+    assert_equal('15', @bucket.tail.id)
+    assert_equal('14', @bucket.head.id)
+  end
+
+  def test_attempt_eviction_not_pingable
+    @bucket.add(Node.new('15', @kn).to_contact)
+    @bucket.add(Node.new('14', @kn).to_contact)
+
+    @kn.nodes.delete_at(1)
+    @bucket.attempt_eviction(Node.new('13', @kn).to_contact)
+
+    assert_equal('13', @bucket.tail.id)
+    assert_equal('14', @bucket.head.id)
+  end
+end

--- a/test/kbucket_6bit_8k_test.rb
+++ b/test/kbucket_6bit_8k_test.rb
@@ -1,0 +1,169 @@
+require_relative 'test_helper.rb'
+require_relative '../lib/node.rb'
+require_relative "../lib/routing_table.rb"
+require_relative "../lib/kbucket.rb"
+require_relative "../lib/contact.rb"
+require_relative "../lib/fake_network_adapter.rb"
+
+class KBucketTest6bit8k < Minitest::Test
+  def setup
+    @kn = FakeNetworkAdapter.new
+    @node = Node.new('0', @kn)
+    @bucket = KBucket.new(@node)
+    @contact = @node.to_contact
+    ENV['bit_length'] = '6'
+    ENV['k'] = '8'
+  end
+
+  def test_create_bucket
+    assert_instance_of(KBucket, @bucket)
+    assert_equal([], @bucket.contacts)
+    assert_equal(true, @bucket.splittable)
+  end
+
+  def test_add_contact
+    @bucket.add(@contact)
+
+    assert_equal(1, @bucket.contacts.size)
+  end
+
+  def test_delete_contact
+    @bucket.add(@contact)
+    @bucket.delete(@bucket.contacts[0])
+
+    assert_equal(0, @bucket.contacts.size)
+  end
+
+  def test_delete_contact_that_is_not_included
+    @bucket.add(@contact)
+    contact = Node.new('1', @kn).to_contact
+    @bucket.delete(contact)
+
+    assert_equal(1, @bucket.contacts.size)
+  end
+
+  def test_head_tail_one_contact
+    @bucket.add(@contact)
+
+    assert_equal(@bucket.contacts[0], @bucket.head)
+    assert_equal(@bucket.contacts[0], @bucket.tail)
+  end
+
+  def test_head_tail_two_contacts
+    @bucket.add(@contact)
+    @bucket.add({ :id => '1', :ip => '' })
+
+    assert_equal(@bucket.contacts[0], @bucket.head)
+    assert_equal(@bucket.contacts[1], @bucket.tail)
+  end
+
+  def test_bucket_is_full
+    @bucket.add(@contact)
+    @bucket.add({ :id => '1', :ip => '' })
+    @bucket.add({ :id => '2', :ip => '' })
+    @bucket.add({ :id => '3', :ip => '' })
+    @bucket.add({ :id => '4', :ip => '' })
+    @bucket.add({ :id => '5', :ip => '' })
+    @bucket.add({ :id => '6', :ip => '' })
+    @bucket.add({ :id => '7', :ip => '' })
+
+    assert(@bucket.is_full?)
+  end
+
+  def test_bucket_is_not_full
+    @bucket.add(@contact)
+
+    refute(@bucket.is_full?)
+  end
+
+  def test_find_contact_by_id
+    @bucket.add(@contact)
+    found_contact = @bucket.find_contact_by_id(@node.id)
+
+    assert_equal(@bucket.contacts[0], found_contact)
+  end
+
+  def test_find_contact_by_id_no_match
+    @bucket.add(@contact)
+    found_contact = @bucket.find_contact_by_id('1')
+
+    assert_nil(found_contact)
+  end
+
+  def test_make_unsplittable
+    @bucket.make_unsplittable
+
+    refute(@bucket.splittable)
+  end
+
+  def test_is_redistributable
+    @bucket.add(Node.new('63', @kn).to_contact)
+    @bucket.add(Node.new('62', @kn).to_contact)
+    @bucket.add(Node.new('61', @kn).to_contact)
+    @bucket.add(Node.new('60', @kn).to_contact)
+    @bucket.add(Node.new('59', @kn).to_contact)
+    @bucket.add(Node.new('58', @kn).to_contact)
+    @bucket.add(Node.new('57', @kn).to_contact)
+    @bucket.add(Node.new('31', @kn).to_contact)
+
+    result = @bucket.is_redistributable?('0', 0)
+    assert(result)
+  end
+
+  def test_is_not_redistributable
+    @bucket.add(Node.new('63', @kn).to_contact)
+    @bucket.add(Node.new('62', @kn).to_contact)
+    @bucket.add(Node.new('61', @kn).to_contact)
+    @bucket.add(Node.new('60', @kn).to_contact)
+    @bucket.add(Node.new('59', @kn).to_contact)
+    @bucket.add(Node.new('58', @kn).to_contact)
+    @bucket.add(Node.new('57', @kn).to_contact)
+    @bucket.add(Node.new('56', @kn).to_contact)
+
+    result = @bucket.is_redistributable?('0', 0)
+    refute(result)
+  end
+
+  def test_sort_by_seen
+    @bucket.add(@contact)
+    @bucket.add(Node.new('7', @kn).to_contact)
+
+    @bucket.head.update_last_seen
+    @bucket.sort_by_seen
+
+    assert_equal('7', @bucket.head.id)
+  end
+
+  def test_attempt_eviction_pingable
+    @bucket.add(Node.new('63', @kn).to_contact)
+    @bucket.add(Node.new('62', @kn).to_contact)
+    @bucket.add(Node.new('61', @kn).to_contact)
+    @bucket.add(Node.new('60', @kn).to_contact)
+    @bucket.add(Node.new('59', @kn).to_contact)
+    @bucket.add(Node.new('58', @kn).to_contact)
+    @bucket.add(Node.new('57', @kn).to_contact)
+    @bucket.add(Node.new('56', @kn).to_contact)
+
+    @bucket.attempt_eviction(Contact.new(id: '55', ip: ''))
+
+    assert_equal('63', @bucket.tail.id)
+    assert_equal('62', @bucket.head.id)
+  end
+
+  def test_attempt_eviction_not_pingable
+    @bucket.add(Node.new('63', @kn).to_contact)
+    @bucket.add(Node.new('62', @kn).to_contact)
+    @bucket.add(Node.new('61', @kn).to_contact)
+    @bucket.add(Node.new('60', @kn).to_contact)
+    @bucket.add(Node.new('59', @kn).to_contact)
+    @bucket.add(Node.new('58', @kn).to_contact)
+    @bucket.add(Node.new('57', @kn).to_contact)
+    @bucket.add(Node.new('56', @kn).to_contact)
+
+    @kn.nodes.delete_at(1)
+    @bucket.attempt_eviction(Node.new('55', @kn).to_contact)
+
+    assert_equal('55', @bucket.tail.id)
+    assert_equal('62', @bucket.head.id)
+  end
+end

--- a/test/node_160bit_8k_3a_test.rb
+++ b/test/node_160bit_8k_3a_test.rb
@@ -1,0 +1,428 @@
+require_relative 'test_helper.rb'
+require_relative "../lib/node.rb"
+require_relative "../lib/routing_table.rb"
+require_relative "../lib/fake_network_adapter.rb"
+require_relative "../lib/kbucket.rb"
+
+class NodeTest160bit8k < Minitest::Test
+  def setup
+    @kn = FakeNetworkAdapter.new
+    ENV['bit_length'] = '160'
+    ENV['k'] = '8'
+    ENV['alpha'] = '3'
+  end
+
+  def test_create_node
+    node = Node.new('0', @kn)
+
+    assert_instance_of(Node, node)
+    assert_instance_of(RoutingTable, node.routing_table)
+  end
+
+  def test_join_network
+    node1 = Node.new('1', @kn)
+    node2 = Node.new('2', @kn)
+
+    assert_includes(@kn.nodes, node1)
+    assert_includes(@kn.nodes, node2)
+  end
+
+  def test_ping_other_node_true_and_false
+    node0 = Node.new('0', @kn)
+    node1 = Node.new('1', @kn)
+    node2 = Node.new('2', @kn)
+
+    assert(node0.ping(node1.to_contact))
+    assert(node0.ping(node2.to_contact))
+    refute(node0.ping(Contact.new(id: '3', ip: '')))
+  end
+
+  def test_ping_dead_node
+    
+  end
+
+  def test_receive_ping
+    node0 = Node.new('0', @kn)
+    node1 = Node.new('1', @kn)
+
+    refute_includes(node0.routing_table.buckets[0].contacts, node1.to_contact)
+    refute_includes(node1.routing_table.buckets[0].contacts, node0.to_contact)
+
+    node0.ping(node1.to_contact)
+
+    assert_equal(1, node1.routing_table.buckets[0].contacts.size)
+    assert_equal(1, node0.routing_table.buckets[0].contacts.size)
+  end
+
+  def test_store
+    node0 = Node.new('0', @kn)
+    node1 = Node.new('1', @kn)
+
+    node0.store('key', 'value', node1.to_contact)
+    assert_equal('value', node1.dht_segment['key'])
+  end
+
+  def test_receive_find_node
+    node0 = Node.new('0', @kn)
+
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    node0.routing_table.insert(node32.to_contact)
+    node0.routing_table.insert(node57.to_contact)
+    node0.routing_table.insert(node58.to_contact)
+    node0.routing_table.insert(node59.to_contact)
+    node0.routing_table.insert(node60.to_contact)
+    node0.routing_table.insert(node61.to_contact)
+    node0.routing_table.insert(node62.to_contact)
+    node0.routing_table.insert(node63.to_contact)
+
+    node12 = Node.new('12', @kn)
+
+    results = node0.receive_find_node('1', node12.to_contact)
+    results.map! { |contact| contact.id }
+
+    refute_empty(results)
+    assert_equal(8, results.size)
+    assert_includes(results, '32')
+    assert_includes(results, '63')
+  end
+
+  def test_receive_find_node_multiple_buckets
+    node0 = Node.new('0', @kn)
+
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+    node7 = Node.new('7', @kn)
+
+    node0.routing_table.insert(node32.to_contact)
+    node0.routing_table.insert(node57.to_contact)
+    node0.routing_table.insert(node58.to_contact)
+    node0.routing_table.insert(node59.to_contact)
+    node0.routing_table.insert(node60.to_contact)
+    node0.routing_table.insert(node61.to_contact)
+    node0.routing_table.insert(node62.to_contact)
+    node0.routing_table.insert(node63.to_contact)
+    node0.routing_table.insert(node7.to_contact)
+
+    node12 = Node.new('12', @kn)
+
+    results = node0.receive_find_node('1', node12.to_contact)
+    results.map! { |contact| contact.id }
+
+    refute_empty(results)
+    assert_equal(8, results.size)
+    assert_includes(results, '7')
+    assert_includes(results, '32')
+    assert_includes(results, '62')
+  end
+
+  def test_receive_find_node_multiple_buckets_starting_from_back
+    node0 = Node.new('0', @kn)
+
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+    node7 = Node.new('7', @kn)
+    node8 = Node.new('8', @kn)
+
+    node0.routing_table.insert(node57.to_contact)
+    node0.routing_table.insert(node58.to_contact)
+    node0.routing_table.insert(node59.to_contact)
+    node0.routing_table.insert(node60.to_contact)
+    node0.routing_table.insert(node61.to_contact)
+    node0.routing_table.insert(node62.to_contact)
+    node0.routing_table.insert(node63.to_contact)
+    node0.routing_table.insert(node7.to_contact)
+    node0.routing_table.insert(node8.to_contact)
+
+    node12 = Node.new('12', @kn)
+
+    results = node0.receive_find_node('40', node12.to_contact)
+    results.map! { |contact| contact.id }
+
+    refute_empty(results)
+    assert_equal(8, results.size)
+    assert_includes(results, '57')
+    assert_includes(results, '63')
+    assert_includes(results, '7')
+    refute_includes(results, '8')
+  end
+
+  def test_receive_find_node_fewer_than_k_results
+    node0 = Node.new('0', @kn)
+    node15 = Node.new('15', @kn)
+    node16 = Node.new('16', @kn)
+    node7 = Node.new('7', @kn)
+
+    node0.routing_table.insert(node15.to_contact)
+    node0.routing_table.insert(node16.to_contact)
+
+    results = node0.receive_find_node('1', node7.to_contact)
+
+    refute_empty(results)
+    assert_equal(2, results.size)
+    assert_equal('15', results.first.id)
+    assert_equal('16', results.last.id)
+  end
+
+  def test_receive_find_node_exclude_requestor
+    node0 = Node.new('0', @kn)
+    node15 = Node.new('15', @kn)
+    node14 = Node.new('14', @kn)
+    node3 = Node.new('3', @kn)
+    node7 = Node.new('7', @kn)
+
+    node15_contact = node15.to_contact
+    node14_contact = node14.to_contact
+    node3_contact = node3.to_contact
+    node7_contact = node7.to_contact
+
+    node0.routing_table.insert(node15_contact)
+    node0.routing_table.insert(node14_contact)
+    node0.routing_table.insert(node3_contact)
+    node0.routing_table.insert(node7_contact)
+
+    results = node0.receive_find_node('1', node7_contact)
+
+    refute_includes(results, node7_contact)
+    assert_equal(3, results.size)
+    assert_includes(results, node15_contact)
+    assert_includes(results, node14_contact)
+    assert_includes(results, node3_contact)
+  end
+
+  def test_find_node
+    node7 = Node.new('7', @kn) # the requestor node
+    node0 = Node.new('0', @kn) # the node that gets the request
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    results = node7.find_node('1', node0.to_contact)
+
+    refute_empty(results)
+    assert_equal(3, results.size)
+    assert_includes(results, node4_contact)
+    assert_includes(results, node5_contact)
+    assert_includes(results, node12_contact)
+  end
+
+  def test_receive_find_value_with_match
+    # return a address
+    node0 = Node.new('0', @kn) # node that received request
+    node0.dht_segment['10'] = 'some_address'
+
+    node7 = Node.new('7', @kn) # node making the request
+
+    result = node0.receive_find_value('10', node7.to_contact)
+
+    assert_equal('some_address', result['data'])
+  end
+
+  def test_receive_find_value_with_no_match
+    # just returns closest nodes
+
+    node0 = Node.new('0', @kn) # node that received request
+    node0.dht_segment['11'] = 'some_address'
+
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node13 = Node.new('13', @kn)
+    node7 = Node.new('7', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+    node13_contact = node13.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+    node0.routing_table.insert(node13_contact)
+
+    results = node0.receive_find_value('10', node7.to_contact)
+
+    refute_empty(results['contacts'])
+    assert_equal(4, results['contacts'].size)
+    assert_includes(results['contacts'], node12_contact)
+    assert_includes(results['contacts'], node13_contact)
+  end
+
+  def test_find_value_with_match
+    node0 = Node.new('0', @kn) # node that received request
+    node0.dht_segment['10'] = 'some_address'
+
+    node7 = Node.new('7', @kn) # node making the request
+
+    result = node7.find_value('10', node0.to_contact)
+
+    assert_equal('some_address', result['data'])
+  end
+
+  def test_find_value_with_no_match
+    node0 = Node.new('0', @kn) # node that received request
+    node0.dht_segment['11'] = 'some_address'
+
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node7 = Node.new('7', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    results = node7.find_value('10', node0.to_contact)
+
+    refute_empty(results['contacts'])
+    assert_equal(3, results['contacts'].size)
+    assert_includes(results['contacts'], node12_contact)
+    assert_includes(results['contacts'], node5_contact)
+    assert_includes(results['contacts'], node4_contact)
+  end
+
+  def test_iterative_find_node
+    # no parallelism
+    node0 = Node.new('0', @kn)
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node9 = Node.new('9', @kn)
+    node10 = Node.new('10', @kn)
+    node11 = Node.new('11', @kn)
+    node12 = Node.new('12', @kn)
+    node14 = Node.new('14', @kn)
+    node13 = Node.new('13', @kn)
+
+    node0.routing_table.insert(node4.to_contact)
+    node0.routing_table.insert(node5.to_contact)
+    node0.routing_table.insert(node9.to_contact)
+    node0.routing_table.insert(node10.to_contact)
+
+    node4.routing_table.insert(node11.to_contact)
+    node4.routing_table.insert(node12.to_contact)
+    node4.routing_table.insert(node13.to_contact)
+
+    node14_contact = node14.to_contact
+
+    node11.routing_table.insert(node14_contact)
+
+    result = node0.iterative_find_node('15').map(&:id)
+
+    assert_instance_of(Array, result)
+    assert_equal(7, result.size)
+    assert_includes(result, '14')
+    assert_includes(result, '12')
+    refute_includes(result, '10')
+    # test that ping adds new contact to our routing table
+    assert_includes(node0.routing_table.buckets[0].map(&:id), node14_contact.id)
+  end
+
+  def test_iterative_store
+    node0 = Node.new('0', @kn)
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node14 = Node.new('14', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+    node14_contact = node14.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    node12.routing_table.insert(node14_contact)
+    node0.iterative_store('13', 'some_address')
+
+    assert_equal('some_address', node12.dht_segment['13'])
+    assert_equal('some_address', node4.dht_segment['13'])
+    assert_equal('some_address', node5.dht_segment['13'])
+    refute(node14.dht_segment['13'])   
+  end
+
+  def test_iterative_find_value_with_match
+    node0 = Node.new('0', @kn)
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node14 = Node.new('14', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+    node14_contact = node14.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    node12.routing_table.insert(node14_contact)
+    node0.store('15', 'some_address', node14_contact)
+
+    result = node0.iterative_find_value('15')
+    assert_instance_of(String, result)
+    assert_equal('some_address', result)
+    # store in second closest node
+    assert_equal('some_address', node4.dht_segment['15'])
+  end
+
+  def test_iterative_find_value_with_no_match
+    node0 = Node.new('0', @kn)
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node14 = Node.new('14', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+    node14_contact = node14.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    node12.routing_table.insert(node14_contact)
+    node0.store('13', 'some_address', node14_contact)
+
+    result = node0.iterative_find_value('15')
+    assert_instance_of(Array, result)
+    assert_equal(4, result.size)
+    assert_includes(result.map(&:id), node4_contact.id)
+    assert_includes(result.map(&:id), node5_contact.id)
+    assert_includes(result.map(&:id), node14_contact.id)
+    assert_includes(result.map(&:id), node12_contact.id)
+  end
+end

--- a/test/node_160bit_test.rb
+++ b/test/node_160bit_test.rb
@@ -9,6 +9,7 @@ class NodeTest160 < Minitest::Test
     @kn = FakeNetworkAdapter.new
     ENV['bit_length'] = '160'
     ENV['k'] = '2'
+    ENV['alpha'] = '1'
   end
 
   def test_create_node

--- a/test/node_4bit_test.rb
+++ b/test/node_4bit_test.rb
@@ -4,11 +4,12 @@ require_relative "../lib/routing_table.rb"
 require_relative "../lib/fake_network_adapter.rb"
 require_relative "../lib/kbucket.rb"
 
-class NodeTest < Minitest::Test
+class NodeTest4bit < Minitest::Test
   def setup
     @kn = FakeNetworkAdapter.new
     ENV['bit_length'] = '4'
     ENV['k'] = '2'
+    ENV['alpha'] = '1'
   end
 
   def test_create_node

--- a/test/node_6bit_8k_3a_test.rb
+++ b/test/node_6bit_8k_3a_test.rb
@@ -1,0 +1,416 @@
+require_relative 'test_helper.rb'
+require_relative "../lib/node.rb"
+require_relative "../lib/routing_table.rb"
+require_relative "../lib/fake_network_adapter.rb"
+require_relative "../lib/kbucket.rb"
+
+class NodeTest6bit8k < Minitest::Test
+  def setup
+    @kn = FakeNetworkAdapter.new
+    ENV['bit_length'] = '6'
+    ENV['k'] = '8'
+    ENV['alpha'] = '3'
+  end
+
+  def test_create_node
+    node = Node.new('0', @kn)
+
+    assert_instance_of(Node, node)
+    assert_instance_of(RoutingTable, node.routing_table)
+  end
+
+  def test_join_network
+    node1 = Node.new('1', @kn)
+    node2 = Node.new('2', @kn)
+
+    assert_includes(@kn.nodes, node1)
+    assert_includes(@kn.nodes, node2)
+  end
+
+  def test_ping_other_node_true_and_false
+    node0 = Node.new('0', @kn)
+    node1 = Node.new('1', @kn)
+    node2 = Node.new('2', @kn)
+
+    assert(node0.ping(node1.to_contact))
+    assert(node0.ping(node2.to_contact))
+    refute(node0.ping(Contact.new(id: '3', ip: '')))
+  end
+
+  def test_ping_dead_node
+    
+  end
+
+  def test_receive_ping
+    node0 = Node.new('0', @kn)
+    node1 = Node.new('1', @kn)
+
+    refute_includes(node0.routing_table.buckets[0].contacts, node1.to_contact)
+    refute_includes(node1.routing_table.buckets[0].contacts, node0.to_contact)
+
+    node0.ping(node1.to_contact)
+
+    assert_equal(1, node1.routing_table.buckets[0].contacts.size)
+    assert_equal(1, node0.routing_table.buckets[0].contacts.size)
+  end
+
+  def test_store
+    node0 = Node.new('0', @kn)
+    node1 = Node.new('1', @kn)
+
+    node0.store('key', 'value', node1.to_contact)
+    assert_equal('value', node1.dht_segment['key'])
+  end
+
+  def test_receive_find_node
+    node0 = Node.new('0', @kn)
+
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    node0.routing_table.insert(node32.to_contact)
+    node0.routing_table.insert(node57.to_contact)
+    node0.routing_table.insert(node58.to_contact)
+    node0.routing_table.insert(node59.to_contact)
+    node0.routing_table.insert(node60.to_contact)
+    node0.routing_table.insert(node61.to_contact)
+    node0.routing_table.insert(node62.to_contact)
+    node0.routing_table.insert(node63.to_contact)
+
+    node12 = Node.new('12', @kn)
+
+    results = node0.receive_find_node('1', node12.to_contact)
+    results.map! { |contact| contact.id }
+
+    refute_empty(results)
+    assert_equal(8, results.size)
+    assert_includes(results, '32')
+    assert_includes(results, '63')
+  end
+
+  def test_receive_find_node_multiple_buckets
+    node0 = Node.new('0', @kn)
+
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+    node7 = Node.new('7', @kn)
+
+    node0.routing_table.insert(node32.to_contact)
+    node0.routing_table.insert(node57.to_contact)
+    node0.routing_table.insert(node58.to_contact)
+    node0.routing_table.insert(node59.to_contact)
+    node0.routing_table.insert(node60.to_contact)
+    node0.routing_table.insert(node61.to_contact)
+    node0.routing_table.insert(node62.to_contact)
+    node0.routing_table.insert(node63.to_contact)
+    node0.routing_table.insert(node7.to_contact)
+
+    node12 = Node.new('12', @kn)
+
+    results = node0.receive_find_node('1', node12.to_contact)
+    results.map! { |contact| contact.id }
+
+    refute_empty(results)
+    assert_equal(8, results.size)
+    assert_includes(results, '7')
+    assert_includes(results, '32')
+    assert_includes(results, '62')
+  end
+
+  def test_receive_find_node_multiple_buckets_starting_from_back
+    node0 = Node.new('0', @kn)
+
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+    node7 = Node.new('7', @kn)
+    node8 = Node.new('8', @kn)
+
+    node0.routing_table.insert(node57.to_contact)
+    node0.routing_table.insert(node58.to_contact)
+    node0.routing_table.insert(node59.to_contact)
+    node0.routing_table.insert(node60.to_contact)
+    node0.routing_table.insert(node61.to_contact)
+    node0.routing_table.insert(node62.to_contact)
+    node0.routing_table.insert(node63.to_contact)
+    node0.routing_table.insert(node7.to_contact)
+    node0.routing_table.insert(node8.to_contact)
+
+    node12 = Node.new('12', @kn)
+
+    results = node0.receive_find_node('40', node12.to_contact)
+    results.map! { |contact| contact.id }
+
+    refute_empty(results)
+    assert_equal(8, results.size)
+    assert_includes(results, '57')
+    assert_includes(results, '63')
+    assert_includes(results, '7')
+    refute_includes(results, '8')
+  end
+
+  def test_receive_find_node_fewer_than_k_results
+    node0 = Node.new('0', @kn)
+    node15 = Node.new('15', @kn)
+    node7 = Node.new('7', @kn)
+
+    node0.routing_table.insert(node15.to_contact)
+
+    results = node0.receive_find_node('1', node7.to_contact)
+
+    refute_empty(results)
+    assert_equal(1, results.size)
+    assert_equal('15', results.first.id)
+  end
+
+  def test_receive_find_node_exclude_requestor
+    node0 = Node.new('0', @kn)
+    node15 = Node.new('15', @kn)
+    node14 = Node.new('14', @kn)
+    node3 = Node.new('3', @kn)
+    node7 = Node.new('7', @kn)
+
+    node15_contact = node15.to_contact
+    node14_contact = node14.to_contact
+    node3_contact = node3.to_contact
+    node7_contact = node7.to_contact
+
+    node0.routing_table.insert(node15_contact)
+    node0.routing_table.insert(node14_contact)
+    node0.routing_table.insert(node3_contact)
+    node0.routing_table.insert(node7_contact)
+
+    results = node0.receive_find_node('1', node7_contact)
+
+    refute_includes(results, node7_contact)
+    assert_equal(3, results.size)
+    assert_includes(results, node15_contact)
+    assert_includes(results, node14_contact)
+    assert_includes(results, node3_contact)
+  end
+
+  def test_find_node
+    node7 = Node.new('7', @kn) # the requestor node
+    node0 = Node.new('0', @kn) # the node that gets the request
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    results = node7.find_node('1', node0.to_contact)
+
+    refute_empty(results)
+    assert_equal(3, results.size)
+    assert_includes(results, node4_contact)
+    assert_includes(results, node5_contact)
+    assert_includes(results, node12_contact)
+  end
+
+  def test_receive_find_value_with_match
+    # return a address
+    node0 = Node.new('0', @kn) # node that received request
+    node0.dht_segment['10'] = 'some_address'
+
+    node7 = Node.new('7', @kn) # node making the request
+
+    result = node0.receive_find_value('10', node7.to_contact)
+
+    assert_equal('some_address', result['data'])
+  end
+
+  def test_receive_find_value_with_no_match
+    # just returns closest nodes
+
+    node0 = Node.new('0', @kn) # node that received request
+    node0.dht_segment['11'] = 'some_address'
+
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node13 = Node.new('13', @kn)
+    node7 = Node.new('7', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+    node13_contact = node13.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+    node0.routing_table.insert(node13_contact)
+
+    results = node0.receive_find_value('10', node7.to_contact)
+
+    refute_empty(results['contacts'])
+    assert_equal(4, results['contacts'].size)
+    assert_includes(results['contacts'], node12_contact)
+    assert_includes(results['contacts'], node13_contact)
+  end
+
+  def test_find_value_with_match
+    node0 = Node.new('0', @kn) # node that received request
+    node0.dht_segment['10'] = 'some_address'
+
+    node7 = Node.new('7', @kn) # node making the request
+
+    result = node7.find_value('10', node0.to_contact)
+
+    assert_equal('some_address', result['data'])
+  end
+
+  def test_find_value_with_no_match
+    node0 = Node.new('0', @kn) # node that received request
+    node0.dht_segment['11'] = 'some_address'
+
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node7 = Node.new('7', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    results = node7.find_value('10', node0.to_contact)
+
+    refute_empty(results['contacts'])
+    assert_equal(3, results['contacts'].size)
+    assert_includes(results['contacts'], node12_contact)
+    assert_includes(results['contacts'], node4_contact)
+    assert_includes(results['contacts'], node5_contact)
+  end
+
+  def test_iterative_find_node # test fails if alpha = 1
+    node0 = Node.new('0', @kn)
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node14 = Node.new('14', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+    node14_contact = node14.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    node12.routing_table.insert(node14_contact)
+
+    result = node0.iterative_find_node('15')
+    assert_instance_of(Array, result)
+    assert_equal(4, result.size)
+    assert_includes(result.map(&:id), node14_contact.id)
+    assert_includes(result.map(&:id), node12_contact.id)
+    # test that ping adds new contact to our routing table
+    assert_includes(node0.routing_table.buckets[0].map(&:id), node14_contact.id)
+  end
+
+  def test_iterative_store
+    node0 = Node.new('0', @kn)
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node14 = Node.new('14', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+    node14_contact = node14.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    node12.routing_table.insert(node14_contact)
+    node0.iterative_store('13', 'some_address')
+
+    assert_equal('some_address', node12.dht_segment['13'])
+    assert_equal('some_address', node4.dht_segment['13'])
+    assert_equal('some_address', node5.dht_segment['13'])
+    refute(node14.dht_segment['13'])    
+  end
+
+  def test_iterative_find_value_with_match
+    node0 = Node.new('0', @kn)
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node14 = Node.new('14', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+    node14_contact = node14.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    node12.routing_table.insert(node14_contact)
+    node0.store('15', 'some_address', node14_contact)
+
+    result = node0.iterative_find_value('15')
+    assert_instance_of(String, result)
+    assert_equal('some_address', result)
+    # store in second closest node
+    assert_equal('some_address', node4.dht_segment['15'])
+  end
+
+  def test_iterative_find_value_with_no_match
+    node0 = Node.new('0', @kn)
+    node4 = Node.new('4', @kn)
+    node5 = Node.new('5', @kn)
+    node12 = Node.new('12', @kn)
+    node14 = Node.new('14', @kn)
+
+    node4_contact = node4.to_contact
+    node5_contact = node5.to_contact
+    node12_contact = node12.to_contact
+    node14_contact = node14.to_contact
+
+    node0.routing_table.insert(node4_contact)
+    node0.routing_table.insert(node5_contact)
+    node0.routing_table.insert(node12_contact)
+
+    node12.routing_table.insert(node14_contact)
+    node0.store('13', 'some_address', node14_contact)
+
+    result = node0.iterative_find_value('15')
+    assert_instance_of(Array, result)
+    assert_equal(4, result.size)
+    assert_includes(result.map(&:id), node4_contact.id)
+    assert_includes(result.map(&:id), node5_contact.id)
+    assert_includes(result.map(&:id), node14_contact.id)
+    assert_includes(result.map(&:id), node12_contact.id)
+  end
+end

--- a/test/node_6bit_test.rb
+++ b/test/node_6bit_test.rb
@@ -9,6 +9,7 @@ class NodeTest6 < Minitest::Test
     @kn = FakeNetworkAdapter.new
     ENV['bit_length'] = '6'
     ENV['k'] = '2'
+    ENV['alpha'] = '1'
   end
 
   def test_create_node

--- a/test/routing_table_160bit_8k_test.rb
+++ b/test/routing_table_160bit_8k_test.rb
@@ -1,0 +1,360 @@
+require_relative 'test_helper.rb'
+require_relative '../lib/node.rb'
+require_relative "../lib/routing_table.rb"
+require_relative "../lib/kbucket.rb"
+require_relative "../lib/contact.rb"
+require_relative "../lib/fake_network_adapter.rb"
+
+class RoutingTableTest160bit8k < Minitest::Test
+  def setup
+    @kn = FakeNetworkAdapter.new
+    @node = Node.new('0', @kn)
+    @routing_table = @node.routing_table
+    ENV['bit_length'] = '160'
+    ENV['k'] = '8'
+  end
+
+  def test_create_routing_table
+    assert_equal(1, @routing_table.buckets.size)
+  end
+
+  def test_insert_node_with_duplicate_id
+    new_node = Node.new('0',@kn)
+
+    @routing_table.insert(new_node)
+    assert_equal(0, @routing_table.buckets[0].size)
+  end
+
+  def test_insert_if_bucket_not_full
+    node15 = Node.new('15', @kn)
+    node16 = Node.new('16', @kn)
+
+    @routing_table.insert(node15)
+    @routing_table.insert(node16)
+
+    assert_equal(1, @routing_table.buckets.size)
+    assert_equal(2, @routing_table.buckets[0].contacts.size)
+  end
+
+  def test_insert_find_closest_bucket_with_one_bucket_with_closest_shared_bit_length
+    result = @routing_table.find_closest_bucket('1')
+    assert_equal(result, @routing_table.buckets[0])
+  end
+
+  def test_insert_find_closest_bucket_with_two_buckets_no_shared_bit_length
+    @routing_table.create_bucket
+
+    no_shared_id = (2 ** (ENV['bit_length'].to_i - 1)).to_s
+
+    result = @routing_table.find_closest_bucket(no_shared_id)
+
+    assert_equal(result, @routing_table.buckets[0])    
+  end
+
+  def test_insert_find_closest_bucket_with_two_buckets_no_shared_bit_length_bug
+    @routing_table.create_bucket
+
+    no_shared_id = (2 ** (ENV['bit_length'].to_i) - 1).to_s
+
+    result = @routing_table.find_closest_bucket(no_shared_id)
+    
+    assert_equal(result, @routing_table.buckets[0])    
+  end
+
+  def test_insert_find_closest_bucket_with_two_buckets_one_shared_bit
+    @routing_table.create_bucket
+    one_shared_id = (2 ** (ENV['bit_length'].to_i - 2)).to_s
+
+    result = @routing_table.find_closest_bucket(one_shared_id)
+
+    assert_equal(result, @routing_table.buckets[1])
+  end
+
+  def test_insert_find_closest_bucket_with_two_buckets_with_most_shared_bits
+    @routing_table.create_bucket
+    result = @routing_table.find_closest_bucket('1')
+
+    assert_equal(result, @routing_table.buckets[1])
+  end
+
+  def test_insert_find_closest_bucket_with_full_buckets_with_arbitrary_shared_bits
+    total_buckets = ENV['bit_length'].to_i - 1 # create bucket equal to k
+
+    total_buckets.times do
+      @routing_table.create_bucket
+    end
+
+    result2 = @routing_table.find_closest_bucket('2')
+    position = Binary.shared_prefix_bit_length('0', '2')
+    result7 = @routing_table.find_closest_bucket('7')
+    position2 = Binary.shared_prefix_bit_length('0', '7')
+    result15 = @routing_table.find_closest_bucket('15')
+    position3 = Binary.shared_prefix_bit_length('0', '15')
+
+    assert_equal(result2, @routing_table.buckets[position])
+
+    assert_equal(result7, @routing_table.buckets[position2])
+
+    assert_equal(result15, @routing_table.buckets[position3])
+  end
+
+  def test_insert_if_bucket_full_and_splittable_diff_xor_distance
+    node56 = Node.new('56', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node56.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    node7 = Node.new('7', @kn)
+    @routing_table.insert(node7.to_contact)
+
+    index_of_second_last_bucket = Binary.shared_prefix_bit_length('0', '56')
+    
+    assert_equal(index_of_second_last_bucket + 2, @routing_table.buckets.size)
+    assert_equal(8, @routing_table.buckets[index_of_second_last_bucket].contacts.size)
+    assert_equal(1, @routing_table.buckets.last.contacts.size)
+  end
+
+  def test_insert_if_bucket_full_and_splittable_smaller_distance_insert_first
+    node56 = Node.new('56', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node56.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    node80 = Node.new('80', @kn) # this id is further
+
+    index1 = Binary.shared_prefix_bit_length('0', '56')
+    index2 = Binary.shared_prefix_bit_length('0', '80')
+
+    @routing_table.insert(node80.to_contact)
+
+    assert_equal(8, @routing_table.buckets[index1].contacts.size)
+    assert_equal(1, @routing_table.buckets[index2].contacts.size)
+    assert_equal(index1 + 1, @routing_table.buckets.size)
+  end
+
+  def test_insert_if_bucket_full_and_splittable_same_xor_distance
+    node56 = Node.new('56', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node56.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    bucket_idx = Binary.shared_prefix_bit_length('0', '56')
+
+    node55 = Node.new('55', @kn) # same xor distance
+    @routing_table.insert(node55.to_contact)
+
+    assert_equal(8, @routing_table.buckets[bucket_idx].contacts.size)
+    assert_equal(bucket_idx + 1, @routing_table.buckets.size)
+  end
+
+  def test_insert_if_bucket_full_and_splittable_same_xor_distance_bucket_redistributable
+    node31 = Node.new('31', @kn) # smaller xor
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node31.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    bucket_idx = Binary.shared_prefix_bit_length('0', '56') # 154
+
+    node40 = Node.new('40', @kn) # inserting node with same xor distance
+    @routing_table.insert(node40.to_contact)
+
+    assert_equal(8, @routing_table.buckets[bucket_idx].contacts.size)
+    assert_equal(1, @routing_table.buckets.last.contacts.size)
+    assert_equal(bucket_idx + 2, @routing_table.buckets.size) # 156
+  end
+
+  def test_redistribute_one_bucket_to_two
+    no_shared_id = (2 ** (ENV['bit_length'].to_i - 1)).to_s
+    node_no_shared = Node.new(no_shared_id, @kn)
+    node3 = Node.new('3', @kn)
+
+    @routing_table.insert(node_no_shared.to_contact)
+    @routing_table.insert(node3.to_contact)
+
+    @routing_table.create_bucket
+
+    @routing_table.redistribute_contacts
+
+    assert_equal(1, @routing_table.buckets[0].contacts.size)
+    assert_equal(1, @routing_table.buckets[1].contacts.size)
+  end
+
+  def test_insert_if_bucket_full_and_splittable_but_contains_at_least_1_closer_element
+    node31 = Node.new('31', @kn) # smaller xor
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node31.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    bucket_idx = Binary.shared_prefix_bit_length('0', '56')
+
+    node30 = Node.new('30', @kn)
+    @routing_table.insert(node30.to_contact)
+
+    assert_equal(7, @routing_table.buckets[bucket_idx].contacts.size)
+    assert_equal(2, @routing_table.buckets.last.contacts.size)
+    assert_equal(bucket_idx + 2, @routing_table.buckets.size)
+  end
+
+  def test_insert_if_bucket_full_and_not_splittable
+    node56 = Node.new('56', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node56.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    node31 = Node.new('31', @kn)
+    @routing_table.insert(node31.to_contact)
+
+    last_bucket_idx = Binary.shared_prefix_bit_length('0', '31')
+
+    node40 = Node.new('40', @kn)
+    @routing_table.insert(node40.to_contact)
+
+    assert_equal(8, @routing_table.buckets[last_bucket_idx - 1].contacts.size)
+    assert_equal(1, @routing_table.buckets.last.contacts.size)
+    assert_equal(last_bucket_idx + 1, @routing_table.buckets.size)
+  end
+
+  def test_insert_if_bucket_full_and_not_splittable_and_head_node_live
+    node56 = Node.new('56', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node56.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    node31 = Node.new('31', @kn)
+    @routing_table.insert(node31.to_contact)
+
+    bucket_idx = Binary.shared_prefix_bit_length('0', '56')
+
+    node40 = Node.new('40', @kn)
+    @routing_table.insert(node40.to_contact)
+
+    assert_equal('56', @routing_table.buckets[bucket_idx].tail.id)
+    assert_equal('57', @routing_table.buckets[bucket_idx].head.id)
+    assert_equal(bucket_idx + 2, @routing_table.buckets.size)
+  end
+
+  def test_insert_if_bucket_full_and_not_splittable_and_head_node_not_live
+    node56 = Node.new('56', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node56.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    node31 = Node.new('31', @kn)
+    @routing_table.insert(node31.to_contact)
+
+    bucket_idx = Binary.shared_prefix_bit_length('0', '56')
+
+    @kn.nodes.delete_at(1)
+
+    node40 = Node.new('40', @kn)
+    @routing_table.insert(node40.to_contact)
+
+    assert_equal('40', @routing_table.buckets[bucket_idx].tail.id)
+    assert_equal('57', @routing_table.buckets[bucket_idx].head.id)
+    assert_equal(bucket_idx + 2, @routing_table.buckets.size)
+  end
+end

--- a/test/routing_table_6bit_8k_test.rb
+++ b/test/routing_table_6bit_8k_test.rb
@@ -1,0 +1,336 @@
+require_relative 'test_helper.rb'
+require_relative '../lib/node.rb'
+require_relative "../lib/routing_table.rb"
+require_relative "../lib/kbucket.rb"
+require_relative "../lib/contact.rb"
+require_relative "../lib/fake_network_adapter.rb"
+
+class RoutingTableTest6bit8k < Minitest::Test
+  def setup
+    @kn = FakeNetworkAdapter.new
+    @node = Node.new('0', @kn)
+    @routing_table = @node.routing_table
+    ENV['bit_length'] = '6'
+    ENV['k'] = '8'
+    # [32-63] [16-31] [8-15] [4-7] [2-3] [1]
+  end
+
+  def test_create_routing_table
+    assert_equal(1, @routing_table.buckets.size)
+  end
+
+  def test_insert_node_with_duplicate_id
+    new_node = Node.new('0',@kn)
+
+    @routing_table.insert(new_node)
+    assert_equal(0, @routing_table.buckets[0].size)
+  end
+
+  def test_insert_if_bucket_not_full
+    node15 = Node.new('15', @kn)
+
+    @routing_table.insert(node15)
+
+    assert_equal(1, @routing_table.buckets.size)
+    assert_equal(1, @routing_table.buckets[0].contacts.size)
+  end
+
+  def test_insert_find_closest_bucket_with_one_bucket
+    result = @routing_table.find_closest_bucket('1')
+    assert_equal(result, @routing_table.buckets[0])
+  end
+
+  def test_insert_find_closest_bucket_with_two_buckets_no_shared_bits
+    @routing_table.create_bucket
+    result = @routing_table.find_closest_bucket('60')
+
+    assert_equal(result, @routing_table.buckets[0])
+  end
+
+  def test_insert_find_closest_bucket_with_two_buckets_one_shared_bit
+    @routing_table.create_bucket
+    result = @routing_table.find_closest_bucket('31')
+
+    assert_equal(result, @routing_table.buckets[1])
+  end
+
+  def test_insert_find_closest_bucket_with_two_buckets_no_exact_shared_bits
+    @routing_table.create_bucket
+    result = @routing_table.find_closest_bucket('1')
+
+    assert_equal(result, @routing_table.buckets[1])
+  end
+
+  def test_insert_find_closest_bucket_with_k_buckets_no_exact_shared_bits
+    5.times do 
+      @routing_table.create_bucket
+    end
+
+    result1 = @routing_table.find_closest_bucket('1')
+    result7 = @routing_table.find_closest_bucket('7')
+    result63 = @routing_table.find_closest_bucket('63')
+
+    assert_equal(result1, @routing_table.buckets.last)
+    assert_equal(result7, @routing_table.buckets[3])
+    assert_equal(result63, @routing_table.buckets.first)
+  end
+
+  def test_insert_if_bucket_full_and_splittable_diff_xor_distance
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    node7 = Node.new('7', @kn)
+
+    @routing_table.insert(node32.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    @routing_table.insert(node7.to_contact)
+
+    assert_equal(2, @routing_table.buckets.size)
+  end
+
+  def test_insert_if_bucket_full_and_splittable_smaller_distance_insert_first
+    node16 = Node.new('16', @kn)
+    node17 = Node.new('17', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    node40 = Node.new('40', @kn)
+
+    @routing_table.insert(node16.to_contact)
+    @routing_table.insert(node17.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    @routing_table.insert(node40.to_contact)
+
+    assert_equal(2, @routing_table.buckets.size)
+    assert_equal(2, @routing_table.buckets.last.size)
+  end
+
+  def test_insert_if_bucket_full_and_splittable_same_xor_distance
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    node40 = Node.new('40', @kn)
+
+    @routing_table.insert(node32.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    @routing_table.insert(node40.to_contact)
+
+    assert_equal(1, @routing_table.buckets.size)
+  end
+
+  def test_insert_if_bucket_full_and_splittable_same_xor_distance_bucket_redistributable
+    node7 = Node.new('7', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    node40 = Node.new('40', @kn)
+
+    @routing_table.insert(node7.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    @routing_table.insert(node40.to_contact)
+    
+    assert_equal(2, @routing_table.buckets.size)
+  end
+
+  def test_redistribute_one_bucket_to_two
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+
+    node16 = Node.new('16', @kn)
+
+    @routing_table.insert(node32.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+
+    @routing_table.insert(node16.to_contact)
+
+    @routing_table.create_bucket
+
+    @routing_table.redistribute_contacts
+
+    assert_equal(7, @routing_table.buckets[0].contacts.size)
+    assert_equal(1, @routing_table.buckets[1].contacts.size)
+  end
+
+  def test_insert_if_bucket_full_and_splittable_but_contains_at_least_1_closer_element
+    node3 = Node.new('3', @kn)
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node3.to_contact)
+    @routing_table.insert(node32.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+
+    @routing_table.insert(node63.to_contact)
+
+    assert_equal(2, @routing_table.buckets.size)
+  end
+
+  def test_insert_if_bucket_full_and_not_splittable
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node32.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    node7 = Node.new('7', @kn)
+    node6 = Node.new('6', @kn)
+
+    @routing_table.insert(node7.to_contact)
+    @routing_table.insert(node6.to_contact)
+
+    node40 = Node.new('40', @kn)
+    @routing_table.insert(node40.to_contact)
+
+    assert_equal(2, @routing_table.buckets.size)
+  end
+
+  def test_insert_if_bucket_full_and_not_splittable_and_head_node_live
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node32.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    node7 = Node.new('7', @kn)
+    node6 = Node.new('6', @kn)
+
+    @routing_table.insert(node7.to_contact)
+    @routing_table.insert(node6.to_contact)
+
+    node40 = Node.new('40', @kn)
+    @routing_table.insert(node40.to_contact)
+
+    assert_equal('32', @routing_table.buckets[0].tail.id)
+    assert_equal('57', @routing_table.buckets[0].head.id)
+    assert_equal(2, @routing_table.buckets.size)
+  end
+
+  def test_insert_if_bucket_full_and_not_splittable_and_head_node_not_live
+    node32 = Node.new('32', @kn)
+    node57 = Node.new('57', @kn)
+    node58 = Node.new('58', @kn)
+    node59 = Node.new('59', @kn)
+    node60 = Node.new('60', @kn)
+    node61 = Node.new('61', @kn)
+    node62 = Node.new('62', @kn)
+    node63 = Node.new('63', @kn)
+
+    @routing_table.insert(node32.to_contact)
+    @routing_table.insert(node57.to_contact)
+    @routing_table.insert(node58.to_contact)
+    @routing_table.insert(node59.to_contact)
+    @routing_table.insert(node60.to_contact)
+    @routing_table.insert(node61.to_contact)
+    @routing_table.insert(node62.to_contact)
+    @routing_table.insert(node63.to_contact)
+
+    node7 = Node.new('7', @kn)
+    node6 = Node.new('6', @kn)
+
+    @routing_table.insert(node7.to_contact)
+    @routing_table.insert(node6.to_contact)
+
+    @kn.nodes.delete_at(1)
+
+    node40 = Node.new('40', @kn)
+    @routing_table.insert(node40.to_contact)
+
+    assert_equal('40', @routing_table.buckets[0].tail.id)
+    assert_equal('57', @routing_table.buckets[0].head.id)
+    assert_equal(2, @routing_table.buckets.size)
+  end
+end


### PR DESCRIPTION
- Increased bucket size to 8 for all 6 bit and 160 bit tests
- Increased alpha to 3 for 6bit and 160bit node tests, along with 160bit k-bucket test